### PR TITLE
Implement GET endpoint for registered person movements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# Agent Rules
+
+## Hard Rules
+
+- **NEVER install, update, or remove software on the system without explicit user permission.** This includes package managers (winget, choco, npm -g, pip, etc.), CLI tools, SDKs, runtimes, and any other system-level software. Always ask first.

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,6 +4,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Ardalis.GuardClauses" Version="5.0.0" />
+    <PackageVersion Include="Ardalis.Result" Version="10.1.0" />
+    <PackageVersion Include="Ardalis.Result.AspNetCore" Version="10.1.0" />
     <PackageVersion Include="AwesomeAssertions" Version="9.3.0" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Opilo.HazardZoneMonitor.Api/Features/Floors/GetFloors/Feature.cs
+++ b/src/Opilo.HazardZoneMonitor.Api/Features/Floors/GetFloors/Feature.cs
@@ -1,3 +1,4 @@
+using Ardalis.Result.AspNetCore;
 using Opilo.HazardZoneMonitor.Api.Shared.Cqrs;
 using Opilo.HazardZoneMonitor.Api.Shared.Features;
 
@@ -16,8 +17,8 @@ public sealed class Feature : IFeature
             IQueryHandler<Query, Response> handler,
             CancellationToken cancellationToken) =>
         {
-            var response = await handler.Handle(new Query(), cancellationToken);
-            return Results.Ok(response);
+            var result = await handler.Handle(new Query(), cancellationToken);
+            return result.ToMinimalApiResult();
         });
     }
 }

--- a/src/Opilo.HazardZoneMonitor.Api/Features/Floors/GetFloors/Handler.cs
+++ b/src/Opilo.HazardZoneMonitor.Api/Features/Floors/GetFloors/Handler.cs
@@ -1,3 +1,4 @@
+using Ardalis.Result;
 using Microsoft.Extensions.Options;
 using Opilo.HazardZoneMonitor.Api.Shared.Cqrs;
 
@@ -5,8 +6,8 @@ namespace Opilo.HazardZoneMonitor.Api.Features.Floors.GetFloors;
 
 public sealed class Handler(IOptions<FloorOptions> floorOptions) : IQueryHandler<Query, Response>
 {
-    public Task<Response> Handle(Query query, CancellationToken cancellationToken)
+    public Task<Result<Response>> Handle(Query query, CancellationToken cancellationToken)
     {
-        return Task.FromResult(new Response(floorOptions.Value.Floors));
+        return Task.FromResult(Result.Success(new Response(floorOptions.Value.Floors)));
     }
 }

--- a/src/Opilo.HazardZoneMonitor.Api/Features/PersonTracking/GetPersonMovements/Feature.cs
+++ b/src/Opilo.HazardZoneMonitor.Api/Features/PersonTracking/GetPersonMovements/Feature.cs
@@ -17,6 +17,9 @@ public sealed class Feature : IFeature
             IQueryHandler<Query, Response> handler,
             CancellationToken cancellationToken) =>
         {
+            if (!RegisterPersonMovement.Handler.Movements.ContainsKey(id))
+                return Results.NotFound();
+
             var response = await handler.Handle(new Query(id), cancellationToken);
             return Results.Ok(response);
         });

--- a/src/Opilo.HazardZoneMonitor.Api/Features/PersonTracking/GetPersonMovements/Feature.cs
+++ b/src/Opilo.HazardZoneMonitor.Api/Features/PersonTracking/GetPersonMovements/Feature.cs
@@ -1,3 +1,4 @@
+using Ardalis.Result.AspNetCore;
 using Opilo.HazardZoneMonitor.Api.Shared.Cqrs;
 using Opilo.HazardZoneMonitor.Api.Shared.Features;
 
@@ -17,11 +18,8 @@ public sealed class Feature : IFeature
             IQueryHandler<Query, Response> handler,
             CancellationToken cancellationToken) =>
         {
-            if (!RegisterPersonMovement.Handler.Movements.ContainsKey(id))
-                return Results.NotFound();
-
-            var response = await handler.Handle(new Query(id), cancellationToken);
-            return Results.Ok(response);
+            var result = await handler.Handle(new Query(id), cancellationToken);
+            return result.ToMinimalApiResult();
         });
     }
 }

--- a/src/Opilo.HazardZoneMonitor.Api/Features/PersonTracking/GetPersonMovements/Feature.cs
+++ b/src/Opilo.HazardZoneMonitor.Api/Features/PersonTracking/GetPersonMovements/Feature.cs
@@ -1,0 +1,24 @@
+using Opilo.HazardZoneMonitor.Api.Shared.Cqrs;
+using Opilo.HazardZoneMonitor.Api.Shared.Features;
+
+namespace Opilo.HazardZoneMonitor.Api.Features.PersonTracking.GetPersonMovements;
+
+public sealed class Feature : IFeature
+{
+    public void AddServices(IServiceCollection services)
+    {
+        services.AddScoped<IQueryHandler<Query, Response>, Handler>();
+    }
+
+    public void MapEndpoints(IEndpointRouteBuilder app)
+    {
+        app.MapGet("/api/v1/person-movements/{personId:guid}", async (
+            Guid personId,
+            IQueryHandler<Query, Response> handler,
+            CancellationToken cancellationToken) =>
+        {
+            var response = await handler.Handle(new Query(personId), cancellationToken);
+            return Results.Ok(response);
+        });
+    }
+}

--- a/src/Opilo.HazardZoneMonitor.Api/Features/PersonTracking/GetPersonMovements/Feature.cs
+++ b/src/Opilo.HazardZoneMonitor.Api/Features/PersonTracking/GetPersonMovements/Feature.cs
@@ -12,12 +12,12 @@ public sealed class Feature : IFeature
 
     public void MapEndpoints(IEndpointRouteBuilder app)
     {
-        app.MapGet("/api/v1/person-movements/{personId:guid}", async (
-            Guid personId,
+        app.MapGet("/api/v1/person-movements/{id:guid}", async (
+            Guid id,
             IQueryHandler<Query, Response> handler,
             CancellationToken cancellationToken) =>
         {
-            var response = await handler.Handle(new Query(personId), cancellationToken);
+            var response = await handler.Handle(new Query(id), cancellationToken);
             return Results.Ok(response);
         });
     }

--- a/src/Opilo.HazardZoneMonitor.Api/Features/PersonTracking/GetPersonMovements/Handler.cs
+++ b/src/Opilo.HazardZoneMonitor.Api/Features/PersonTracking/GetPersonMovements/Handler.cs
@@ -6,6 +6,7 @@ public sealed class Handler : IQueryHandler<Query, Response>
 {
     public Task<Response> Handle(Query query, CancellationToken cancellationToken)
     {
-        return Task.FromResult(new Response(query.PersonId));
+        var movement = RegisterPersonMovement.Handler.Movements[query.Id];
+        return Task.FromResult(new Response(movement.PersonId, movement.X, movement.Y, movement.RegisteredAt));
     }
 }

--- a/src/Opilo.HazardZoneMonitor.Api/Features/PersonTracking/GetPersonMovements/Handler.cs
+++ b/src/Opilo.HazardZoneMonitor.Api/Features/PersonTracking/GetPersonMovements/Handler.cs
@@ -10,6 +10,6 @@ public sealed class Handler : IQueryHandler<Query, Response>
         if (!RegisterPersonMovement.Handler.Movements.TryGetValue(query.Id, out var movement))
             return Task.FromResult(Result<Response>.NotFound());
 
-        return Task.FromResult(Result.Success(new Response(movement.PersonId, movement.X, movement.Y, movement.RegisteredAt)));
+        return Task.FromResult(Result.Success(new Response(query.Id, movement.PersonId, movement.X, movement.Y, movement.RegisteredAt)));
     }
 }

--- a/src/Opilo.HazardZoneMonitor.Api/Features/PersonTracking/GetPersonMovements/Handler.cs
+++ b/src/Opilo.HazardZoneMonitor.Api/Features/PersonTracking/GetPersonMovements/Handler.cs
@@ -1,12 +1,15 @@
+using Ardalis.Result;
 using Opilo.HazardZoneMonitor.Api.Shared.Cqrs;
 
 namespace Opilo.HazardZoneMonitor.Api.Features.PersonTracking.GetPersonMovements;
 
 public sealed class Handler : IQueryHandler<Query, Response>
 {
-    public Task<Response> Handle(Query query, CancellationToken cancellationToken)
+    public Task<Result<Response>> Handle(Query query, CancellationToken cancellationToken)
     {
-        var movement = RegisterPersonMovement.Handler.Movements[query.Id];
-        return Task.FromResult(new Response(movement.PersonId, movement.X, movement.Y, movement.RegisteredAt));
+        if (!RegisterPersonMovement.Handler.Movements.TryGetValue(query.Id, out var movement))
+            return Task.FromResult(Result<Response>.NotFound());
+
+        return Task.FromResult(Result.Success(new Response(movement.PersonId, movement.X, movement.Y, movement.RegisteredAt)));
     }
 }

--- a/src/Opilo.HazardZoneMonitor.Api/Features/PersonTracking/GetPersonMovements/Handler.cs
+++ b/src/Opilo.HazardZoneMonitor.Api/Features/PersonTracking/GetPersonMovements/Handler.cs
@@ -1,0 +1,11 @@
+using Opilo.HazardZoneMonitor.Api.Shared.Cqrs;
+
+namespace Opilo.HazardZoneMonitor.Api.Features.PersonTracking.GetPersonMovements;
+
+public sealed class Handler : IQueryHandler<Query, Response>
+{
+    public Task<Response> Handle(Query query, CancellationToken cancellationToken)
+    {
+        return Task.FromResult(new Response(query.PersonId));
+    }
+}

--- a/src/Opilo.HazardZoneMonitor.Api/Features/PersonTracking/GetPersonMovements/Query.cs
+++ b/src/Opilo.HazardZoneMonitor.Api/Features/PersonTracking/GetPersonMovements/Query.cs
@@ -2,4 +2,4 @@ using Opilo.HazardZoneMonitor.Api.Shared.Cqrs;
 
 namespace Opilo.HazardZoneMonitor.Api.Features.PersonTracking.GetPersonMovements;
 
-public sealed record Query(Guid PersonId) : IQuery<Response>;
+public sealed record Query(Guid Id) : IQuery<Response>;

--- a/src/Opilo.HazardZoneMonitor.Api/Features/PersonTracking/GetPersonMovements/Query.cs
+++ b/src/Opilo.HazardZoneMonitor.Api/Features/PersonTracking/GetPersonMovements/Query.cs
@@ -1,0 +1,5 @@
+using Opilo.HazardZoneMonitor.Api.Shared.Cqrs;
+
+namespace Opilo.HazardZoneMonitor.Api.Features.PersonTracking.GetPersonMovements;
+
+public sealed record Query(Guid PersonId) : IQuery<Response>;

--- a/src/Opilo.HazardZoneMonitor.Api/Features/PersonTracking/GetPersonMovements/Response.cs
+++ b/src/Opilo.HazardZoneMonitor.Api/Features/PersonTracking/GetPersonMovements/Response.cs
@@ -2,4 +2,4 @@ using Opilo.HazardZoneMonitor.Api.Shared.Cqrs;
 
 namespace Opilo.HazardZoneMonitor.Api.Features.PersonTracking.GetPersonMovements;
 
-public sealed record Response(Guid PersonId, double X, double Y, DateTime RegisteredAt) : IResponse;
+public sealed record Response(Guid Id, Guid PersonId, double X, double Y, DateTime RegisteredAt) : IResponse;

--- a/src/Opilo.HazardZoneMonitor.Api/Features/PersonTracking/GetPersonMovements/Response.cs
+++ b/src/Opilo.HazardZoneMonitor.Api/Features/PersonTracking/GetPersonMovements/Response.cs
@@ -1,0 +1,5 @@
+using Opilo.HazardZoneMonitor.Api.Shared.Cqrs;
+
+namespace Opilo.HazardZoneMonitor.Api.Features.PersonTracking.GetPersonMovements;
+
+public sealed record Response(Guid PersonId) : IResponse;

--- a/src/Opilo.HazardZoneMonitor.Api/Features/PersonTracking/GetPersonMovements/Response.cs
+++ b/src/Opilo.HazardZoneMonitor.Api/Features/PersonTracking/GetPersonMovements/Response.cs
@@ -2,4 +2,4 @@ using Opilo.HazardZoneMonitor.Api.Shared.Cqrs;
 
 namespace Opilo.HazardZoneMonitor.Api.Features.PersonTracking.GetPersonMovements;
 
-public sealed record Response(Guid PersonId) : IResponse;
+public sealed record Response(Guid PersonId, double X, double Y, DateTime RegisteredAt) : IResponse;

--- a/src/Opilo.HazardZoneMonitor.Api/Features/PersonTracking/RegisterPersonMovement/Feature.cs
+++ b/src/Opilo.HazardZoneMonitor.Api/Features/PersonTracking/RegisterPersonMovement/Feature.cs
@@ -20,7 +20,7 @@ public sealed class Feature : IFeature
         {
             var response = await handler.Handle(command, cancellationToken);
             return TypedResults.Created(
-                new Uri($"/api/v1/person-movements/{response.PersonId}", UriKind.Relative),
+                new Uri($"/api/v1/person-movements/{response.Id}", UriKind.Relative),
                 response);
         });
     }

--- a/src/Opilo.HazardZoneMonitor.Api/Features/PersonTracking/RegisterPersonMovement/Feature.cs
+++ b/src/Opilo.HazardZoneMonitor.Api/Features/PersonTracking/RegisterPersonMovement/Feature.cs
@@ -1,3 +1,4 @@
+using Ardalis.Result.AspNetCore;
 using Microsoft.AspNetCore.Mvc;
 using Opilo.HazardZoneMonitor.Api.Shared.Cqrs;
 using Opilo.HazardZoneMonitor.Api.Shared.Features;
@@ -18,10 +19,8 @@ public sealed class Feature : IFeature
             ICommandHandler<Command, Response> handler,
             CancellationToken cancellationToken) =>
         {
-            var response = await handler.Handle(command, cancellationToken);
-            return TypedResults.Created(
-                new Uri($"/api/v1/person-movements/{response.Id}", UriKind.Relative),
-                response);
+            var result = await handler.Handle(command, cancellationToken);
+            return result.ToMinimalApiResult();
         });
     }
 }

--- a/src/Opilo.HazardZoneMonitor.Api/Features/PersonTracking/RegisterPersonMovement/Feature.cs
+++ b/src/Opilo.HazardZoneMonitor.Api/Features/PersonTracking/RegisterPersonMovement/Feature.cs
@@ -20,6 +20,15 @@ public sealed class Feature : IFeature
             CancellationToken cancellationToken) =>
         {
             var result = await handler.Handle(command, cancellationToken);
+
+            if (result.IsSuccess)
+            {
+                var response = result.Value;
+                return Results.Created(
+                    new Uri($"/api/v1/person-movements/{response.Id}", UriKind.Relative),
+                    response);
+            }
+
             return result.ToMinimalApiResult();
         });
     }

--- a/src/Opilo.HazardZoneMonitor.Api/Features/PersonTracking/RegisterPersonMovement/Handler.cs
+++ b/src/Opilo.HazardZoneMonitor.Api/Features/PersonTracking/RegisterPersonMovement/Handler.cs
@@ -10,8 +10,9 @@ public sealed class Handler : ICommandHandler<Command, Response>
 
     public Task<Result<Response>> Handle(Command command, CancellationToken cancellationToken)
     {
-        var response = new Response(command.PersonId, command.X, command.Y);
-        Movements[response.Id] = (command.PersonId, command.X, command.Y, DateTime.UtcNow);
+        var registeredAt = DateTime.UtcNow;
+        var response = new Response(command.PersonId, command.X, command.Y, registeredAt);
+        Movements[response.Id] = (command.PersonId, command.X, command.Y, registeredAt);
         return Task.FromResult(Result.Created(response));
     }
 }

--- a/src/Opilo.HazardZoneMonitor.Api/Features/PersonTracking/RegisterPersonMovement/Handler.cs
+++ b/src/Opilo.HazardZoneMonitor.Api/Features/PersonTracking/RegisterPersonMovement/Handler.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using Ardalis.Result;
 using Opilo.HazardZoneMonitor.Api.Shared.Cqrs;
 
 namespace Opilo.HazardZoneMonitor.Api.Features.PersonTracking.RegisterPersonMovement;
@@ -7,10 +8,10 @@ public sealed class Handler : ICommandHandler<Command, Response>
 {
     internal static readonly ConcurrentDictionary<Guid, (Guid PersonId, double X, double Y, DateTime RegisteredAt)> Movements = new();
 
-    public Task<Response> Handle(Command command, CancellationToken cancellationToken)
+    public Task<Result<Response>> Handle(Command command, CancellationToken cancellationToken)
     {
-        var id = Guid.CreateVersion7();
-        Movements[id] = (command.PersonId, command.X, command.Y, DateTime.UtcNow);
-        return Task.FromResult(new Response(id));
+        var response = new Response(command.PersonId, command.X, command.Y);
+        Movements[response.Id] = (command.PersonId, command.X, command.Y, DateTime.UtcNow);
+        return Task.FromResult(Result.Created(response));
     }
 }

--- a/src/Opilo.HazardZoneMonitor.Api/Features/PersonTracking/RegisterPersonMovement/Handler.cs
+++ b/src/Opilo.HazardZoneMonitor.Api/Features/PersonTracking/RegisterPersonMovement/Handler.cs
@@ -1,11 +1,16 @@
+using System.Collections.Concurrent;
 using Opilo.HazardZoneMonitor.Api.Shared.Cqrs;
 
 namespace Opilo.HazardZoneMonitor.Api.Features.PersonTracking.RegisterPersonMovement;
 
 public sealed class Handler : ICommandHandler<Command, Response>
 {
+    internal static readonly ConcurrentDictionary<Guid, (Guid PersonId, double X, double Y, DateTime RegisteredAt)> Movements = new();
+
     public Task<Response> Handle(Command command, CancellationToken cancellationToken)
     {
-        return Task.FromResult(new Response(command.PersonId));
+        var id = Guid.CreateVersion7();
+        Movements[id] = (command.PersonId, command.X, command.Y, DateTime.UtcNow);
+        return Task.FromResult(new Response(id));
     }
 }

--- a/src/Opilo.HazardZoneMonitor.Api/Features/PersonTracking/RegisterPersonMovement/Response.cs
+++ b/src/Opilo.HazardZoneMonitor.Api/Features/PersonTracking/RegisterPersonMovement/Response.cs
@@ -2,10 +2,11 @@ using Opilo.HazardZoneMonitor.Api.Shared.Cqrs;
 
 namespace Opilo.HazardZoneMonitor.Api.Features.PersonTracking.RegisterPersonMovement;
 
-public sealed class Response(Guid personId, double x, double y) : IResponse
+public sealed class Response(Guid personId, double x, double y, DateTime registeredAt) : IResponse
 {
     public Guid Id { get; } = Guid.CreateVersion7();
     public Guid PersonId => personId;
     public double X => x;
     public double Y => y;
+    public DateTime RegisteredAt => registeredAt;
 }

--- a/src/Opilo.HazardZoneMonitor.Api/Features/PersonTracking/RegisterPersonMovement/Response.cs
+++ b/src/Opilo.HazardZoneMonitor.Api/Features/PersonTracking/RegisterPersonMovement/Response.cs
@@ -2,4 +2,4 @@ using Opilo.HazardZoneMonitor.Api.Shared.Cqrs;
 
 namespace Opilo.HazardZoneMonitor.Api.Features.PersonTracking.RegisterPersonMovement;
 
-public sealed record Response(Guid PersonId) : IResponse;
+public sealed record Response(Guid Id) : IResponse;

--- a/src/Opilo.HazardZoneMonitor.Api/Features/PersonTracking/RegisterPersonMovement/Response.cs
+++ b/src/Opilo.HazardZoneMonitor.Api/Features/PersonTracking/RegisterPersonMovement/Response.cs
@@ -2,4 +2,10 @@ using Opilo.HazardZoneMonitor.Api.Shared.Cqrs;
 
 namespace Opilo.HazardZoneMonitor.Api.Features.PersonTracking.RegisterPersonMovement;
 
-public sealed record Response(Guid Id) : IResponse;
+public sealed class Response(Guid personId, double x, double y) : IResponse
+{
+    public Guid Id { get; } = Guid.CreateVersion7();
+    public Guid PersonId => personId;
+    public double X => x;
+    public double Y => y;
+}

--- a/src/Opilo.HazardZoneMonitor.Api/Opilo.HazardZoneMonitor.Api.csproj
+++ b/src/Opilo.HazardZoneMonitor.Api/Opilo.HazardZoneMonitor.Api.csproj
@@ -10,6 +10,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Ardalis.Result" />
+    <PackageReference Include="Ardalis.Result.AspNetCore" />
     <PackageReference Include="Dapper" />
     <PackageReference Include="Meziantou.Analyzer">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Opilo.HazardZoneMonitor.Api/Shared/Cqrs/ICommandHandler.cs
+++ b/src/Opilo.HazardZoneMonitor.Api/Shared/Cqrs/ICommandHandler.cs
@@ -1,8 +1,10 @@
-﻿namespace Opilo.HazardZoneMonitor.Api.Shared.Cqrs;
+﻿using Ardalis.Result;
+
+namespace Opilo.HazardZoneMonitor.Api.Shared.Cqrs;
 
 public interface ICommandHandler<TCommand, TResponse>
     where TCommand : ICommand<TResponse>
     where TResponse : IResponse
 {
-    Task<TResponse> Handle(TCommand command, CancellationToken cancellationToken);
+    Task<Result<TResponse>> Handle(TCommand command, CancellationToken cancellationToken);
 }

--- a/src/Opilo.HazardZoneMonitor.Api/Shared/Cqrs/IQueryHandler.cs
+++ b/src/Opilo.HazardZoneMonitor.Api/Shared/Cqrs/IQueryHandler.cs
@@ -1,8 +1,10 @@
-﻿namespace Opilo.HazardZoneMonitor.Api.Shared.Cqrs;
+using Ardalis.Result;
+
+namespace Opilo.HazardZoneMonitor.Api.Shared.Cqrs;
 
 public interface IQueryHandler<in TQuery, TResponse>
     where TQuery : IQuery<TResponse>
     where TResponse : IResponse
 {
-    Task<TResponse> Handle(TQuery query, CancellationToken cancellationToken);
+    Task<Result<TResponse>> Handle(TQuery query, CancellationToken cancellationToken);
 }

--- a/tests/Opilo.HazardZoneMonitor.Tests.Integration/Features/PersonTracking/GetPersonMovementsSpecification.cs
+++ b/tests/Opilo.HazardZoneMonitor.Tests.Integration/Features/PersonTracking/GetPersonMovementsSpecification.cs
@@ -9,17 +9,18 @@ public class GetPersonMovementsSpecification(CustomWebApplicationFactory factory
     : IClassFixture<CustomWebApplicationFactory>
 {
     [Fact]
-    public async Task GetPersonMovements_ShouldReturn200Ok_WhenCalled()
+    public async Task GetPersonMovement_ShouldReturn200Ok_WhenCalled()
     {
         // Arrange
         var client = factory.CreateClient();
         var personId = Guid.NewGuid();
         var command = new Command(personId, X: 1, Y: 1);
-        await client.PostAsJsonAsync("/api/v1/person-movements", command, TestContext.Current.CancellationToken);
+        var postResponse = await client.PostAsJsonAsync("/api/v1/person-movements", command, TestContext.Current.CancellationToken);
+        var registration = await postResponse.Content.ReadFromJsonAsync<RegistrationResponse>(TestContext.Current.CancellationToken);
 
         // Act
         var response = await client.GetAsync(
-            new Uri($"/api/v1/person-movements/{personId}", UriKind.Relative),
+            new Uri($"/api/v1/person-movements/{registration!.Id}", UriKind.Relative),
             TestContext.Current.CancellationToken);
 
         // Assert
@@ -27,24 +28,22 @@ public class GetPersonMovementsSpecification(CustomWebApplicationFactory factory
     }
 
     [Fact]
-    public async Task GetPersonMovements_ShouldReturnMovementsWithRegisteredAtTimestamp_WhenMovementsAreRegistered()
+    public async Task GetPersonMovement_ShouldReturnMovementWithRegisteredAtTimestamp_WhenMovementIsRegistered()
     {
         // Arrange
         var client = factory.CreateClient();
         var personId = Guid.NewGuid();
         var command = new Command(personId, X: 5, Y: 10);
-        await client.PostAsJsonAsync("/api/v1/person-movements", command, TestContext.Current.CancellationToken);
+        var postResponse = await client.PostAsJsonAsync("/api/v1/person-movements", command, TestContext.Current.CancellationToken);
+        var registration = await postResponse.Content.ReadFromJsonAsync<RegistrationResponse>(TestContext.Current.CancellationToken);
 
         // Act
-        var response = await client.GetFromJsonAsync<List<PersonMovementResponse>>(
-            new Uri($"/api/v1/person-movements/{personId}", UriKind.Relative),
+        var movement = await client.GetFromJsonAsync<PersonMovementResponse>(
+            new Uri($"/api/v1/person-movements/{registration!.Id}", UriKind.Relative),
             TestContext.Current.CancellationToken);
 
         // Assert
-        response.Should().NotBeNull();
-        response.Should().NotBeEmpty();
-        response.Should().HaveCount(1);
-        var movement = response[0];
+        movement.Should().NotBeNull();
         movement.PersonId.Should().Be(personId);
         movement.X.Should().Be(5);
         movement.Y.Should().Be(10);
@@ -53,6 +52,7 @@ public class GetPersonMovementsSpecification(CustomWebApplicationFactory factory
 
     // ReSharper disable NotAccessedPositionalProperty.Local
 #pragma warning disable CA1812 // Instantiated by JSON deserialization
+    private sealed record RegistrationResponse(Guid Id);
     private sealed record PersonMovementResponse(Guid PersonId, double X, double Y, DateTime RegisteredAt);
 #pragma warning restore CA1812
     // ReSharper restore NotAccessedPositionalProperty.Local

--- a/tests/Opilo.HazardZoneMonitor.Tests.Integration/Features/PersonTracking/GetPersonMovementsSpecification.cs
+++ b/tests/Opilo.HazardZoneMonitor.Tests.Integration/Features/PersonTracking/GetPersonMovementsSpecification.cs
@@ -50,11 +50,26 @@ public class GetPersonMovementsSpecification(CustomWebApplicationFactory factory
         movement.RegisteredAt.Should().NotBe(default(DateTime));
     }
 
+    [Fact]
+    public async Task GetPersonMovement_ShouldReturn404NotFound_WhenMovementDoesNotExist()
+    {
+        // Arrange
+        var client = factory.CreateClient();
+        var nonExistentId = Guid.NewGuid();
+
+        // Act
+        var response = await client.GetAsync(
+            new Uri($"/api/v1/person-movements/{nonExistentId}", UriKind.Relative),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
     // ReSharper disable NotAccessedPositionalProperty.Local
 #pragma warning disable CA1812 // Instantiated by JSON deserialization
     private sealed record RegistrationResponse(Guid Id);
     private sealed record PersonMovementResponse(Guid PersonId, double X, double Y, DateTime RegisteredAt);
 #pragma warning restore CA1812
     // ReSharper restore NotAccessedPositionalProperty.Local
-
 }

--- a/tests/Opilo.HazardZoneMonitor.Tests.Integration/Features/PersonTracking/GetPersonMovementsSpecification.cs
+++ b/tests/Opilo.HazardZoneMonitor.Tests.Integration/Features/PersonTracking/GetPersonMovementsSpecification.cs
@@ -1,0 +1,28 @@
+using System.Net;
+using System.Net.Http.Json;
+using Opilo.HazardZoneMonitor.Api.Features.PersonTracking.RegisterPersonMovement;
+using Opilo.HazardZoneMonitor.Tests.Integration.Shared;
+
+namespace Opilo.HazardZoneMonitor.Tests.Integration.Features.PersonTracking;
+
+public class GetPersonMovementsSpecification(CustomWebApplicationFactory factory)
+    : IClassFixture<CustomWebApplicationFactory>
+{
+    [Fact]
+    public async Task GetPersonMovements_ShouldReturn200Ok_WhenCalled()
+    {
+        // Arrange
+        var client = factory.CreateClient();
+        var personId = Guid.NewGuid();
+        var command = new Command(personId, X: 1, Y: 1);
+        await client.PostAsJsonAsync("/api/v1/person-movements", command, TestContext.Current.CancellationToken);
+
+        // Act
+        var response = await client.GetAsync(
+            new Uri($"/api/v1/person-movements/{personId}", UriKind.Relative),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+}

--- a/tests/Opilo.HazardZoneMonitor.Tests.Integration/Features/PersonTracking/GetPersonMovementsSpecification.cs
+++ b/tests/Opilo.HazardZoneMonitor.Tests.Integration/Features/PersonTracking/GetPersonMovementsSpecification.cs
@@ -47,6 +47,7 @@ public class GetPersonMovementsSpecification(CustomWebApplicationFactory factory
 
         // Assert
         movement.Should().NotBeNull();
+        movement.Id.Should().Be(registrationId);
         movement.PersonId.Should().Be(personId);
         movement.X.Should().Be(5);
         movement.Y.Should().Be(10);

--- a/tests/Opilo.HazardZoneMonitor.Tests.Integration/Features/PersonTracking/GetPersonMovementsSpecification.cs
+++ b/tests/Opilo.HazardZoneMonitor.Tests.Integration/Features/PersonTracking/GetPersonMovementsSpecification.cs
@@ -3,6 +3,9 @@ using System.Net.Http.Json;
 using Opilo.HazardZoneMonitor.Api.Features.PersonTracking.RegisterPersonMovement;
 using Opilo.HazardZoneMonitor.Tests.Integration.Shared;
 
+using RegisterMovementResponse = Opilo.HazardZoneMonitor.Api.Features.PersonTracking.RegisterPersonMovement.Response;
+using GetMovementResponse = Opilo.HazardZoneMonitor.Api.Features.PersonTracking.GetPersonMovements.Response;
+
 namespace Opilo.HazardZoneMonitor.Tests.Integration.Features.PersonTracking;
 
 public class GetPersonMovementsSpecification(CustomWebApplicationFactory factory)
@@ -16,11 +19,11 @@ public class GetPersonMovementsSpecification(CustomWebApplicationFactory factory
         var personId = Guid.NewGuid();
         var command = new Command(personId, X: 1, Y: 1);
         var postResponse = await client.PostAsJsonAsync("/api/v1/person-movements", command, TestContext.Current.CancellationToken);
-        var registration = await postResponse.Content.ReadFromJsonAsync<RegistrationResponse>(TestContext.Current.CancellationToken);
+        var registration = await postResponse.Content.ReadFromJsonAsync<RegisterMovementResponse>(TestContext.Current.CancellationToken);
 
         // Act
         var response = await client.GetAsync(
-            new Uri($"/api/v1/person-movements/{registration!.Id}", UriKind.Relative),
+            new Uri($"/api/v1/person-movements/{registration!.Id.ToString()}", UriKind.Relative),
             TestContext.Current.CancellationToken);
 
         // Assert
@@ -35,11 +38,11 @@ public class GetPersonMovementsSpecification(CustomWebApplicationFactory factory
         var personId = Guid.NewGuid();
         var command = new Command(personId, X: 5, Y: 10);
         var postResponse = await client.PostAsJsonAsync("/api/v1/person-movements", command, TestContext.Current.CancellationToken);
-        var registration = await postResponse.Content.ReadFromJsonAsync<RegistrationResponse>(TestContext.Current.CancellationToken);
+        var registration = await postResponse.Content.ReadFromJsonAsync<RegisterMovementResponse>(TestContext.Current.CancellationToken);
 
         // Act
-        var movement = await client.GetFromJsonAsync<PersonMovementResponse>(
-            new Uri($"/api/v1/person-movements/{registration!.Id}", UriKind.Relative),
+        var movement = await client.GetFromJsonAsync<GetMovementResponse>(
+            new Uri($"/api/v1/person-movements/{registration!.Id.ToString()}", UriKind.Relative),
             TestContext.Current.CancellationToken);
 
         // Assert
@@ -65,11 +68,4 @@ public class GetPersonMovementsSpecification(CustomWebApplicationFactory factory
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
-
-    // ReSharper disable NotAccessedPositionalProperty.Local
-#pragma warning disable CA1812 // Instantiated by JSON deserialization
-    private sealed record RegistrationResponse(Guid Id);
-    private sealed record PersonMovementResponse(Guid PersonId, double X, double Y, DateTime RegisteredAt);
-#pragma warning restore CA1812
-    // ReSharper restore NotAccessedPositionalProperty.Local
 }

--- a/tests/Opilo.HazardZoneMonitor.Tests.Integration/Features/PersonTracking/GetPersonMovementsSpecification.cs
+++ b/tests/Opilo.HazardZoneMonitor.Tests.Integration/Features/PersonTracking/GetPersonMovementsSpecification.cs
@@ -25,4 +25,36 @@ public class GetPersonMovementsSpecification(CustomWebApplicationFactory factory
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
+
+    [Fact]
+    public async Task GetPersonMovements_ShouldReturnMovementsWithRegisteredAtTimestamp_WhenMovementsAreRegistered()
+    {
+        // Arrange
+        var client = factory.CreateClient();
+        var personId = Guid.NewGuid();
+        var command = new Command(personId, X: 5, Y: 10);
+        await client.PostAsJsonAsync("/api/v1/person-movements", command, TestContext.Current.CancellationToken);
+
+        // Act
+        var response = await client.GetFromJsonAsync<List<PersonMovementResponse>>(
+            new Uri($"/api/v1/person-movements/{personId}", UriKind.Relative),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        response.Should().NotBeNull();
+        response.Should().NotBeEmpty();
+        response.Should().HaveCount(1);
+        var movement = response[0];
+        movement.PersonId.Should().Be(personId);
+        movement.X.Should().Be(5);
+        movement.Y.Should().Be(10);
+        movement.RegisteredAt.Should().NotBe(default(DateTime));
+    }
+
+    // ReSharper disable NotAccessedPositionalProperty.Local
+#pragma warning disable CA1812 // Instantiated by JSON deserialization
+    private sealed record PersonMovementResponse(Guid PersonId, double X, double Y, DateTime RegisteredAt);
+#pragma warning restore CA1812
+    // ReSharper restore NotAccessedPositionalProperty.Local
+
 }

--- a/tests/Opilo.HazardZoneMonitor.Tests.Integration/Features/PersonTracking/RegisterPersonMovementsSpecification.cs
+++ b/tests/Opilo.HazardZoneMonitor.Tests.Integration/Features/PersonTracking/RegisterPersonMovementsSpecification.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Net.Http.Json;
+using System.Text.Json;
 using Opilo.HazardZoneMonitor.Api.Features.PersonTracking.RegisterPersonMovement;
 using Opilo.HazardZoneMonitor.Tests.Integration.Shared;
 
@@ -21,5 +22,40 @@ public class RegisterPersonMovementsSpecification(CustomWebApplicationFactory fa
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Created);
+    }
+
+    [Fact]
+    public async Task RegisterPersonMovement_ShouldIncludeRegisteredAtTimestamp_WhenCalled()
+    {
+        // Arrange
+        var client = factory.CreateClient();
+        var personId = Guid.NewGuid();
+        var request = new Command(personId, X: 1, Y: 1);
+
+        // Act
+        var response = await client.PostAsJsonAsync("/api/v1/person-movements", request, TestContext.Current.CancellationToken);
+
+        // Assert
+        var json = await response.Content.ReadFromJsonAsync<JsonElement>(TestContext.Current.CancellationToken);
+        var registeredAt = json.GetProperty("registeredAt").GetDateTime();
+        registeredAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public async Task RegisterPersonMovement_ShouldReturnLocationHeader_WhenCalled()
+    {
+        // Arrange
+        var client = factory.CreateClient();
+        var personId = Guid.NewGuid();
+        var request = new Command(personId, X: 1, Y: 1);
+
+        // Act
+        var response = await client.PostAsJsonAsync("/api/v1/person-movements", request, TestContext.Current.CancellationToken);
+
+        // Assert
+        var json = await response.Content.ReadFromJsonAsync<JsonElement>(TestContext.Current.CancellationToken);
+        var id = json.GetProperty("id").GetGuid();
+        response.Headers.Location.Should().NotBeNull();
+        response.Headers.Location!.ToString().Should().Be($"/api/v1/person-movements/{id}");
     }
 }


### PR DESCRIPTION
## Summary

Closes #18

- Add `GET /api/v1/person-movements/{id}` endpoint that returns a registered movement by its server-generated ID, including `PersonId`, `X`, `Y`, and `RegisteredAt`
- Add `RegisteredAt` timestamp to the `POST /api/v1/person-movements` response so callers receive server-assigned data
- Restore proper `Location` header on the POST `201 Created` response, pointing to `/api/v1/person-movements/{id}`
- Refactor CQRS handler interfaces to use `Ardalis.Result` for consistent response handling and HTTP status mapping
- Add integration tests validating GET 200/404 responses, POST `RegisteredAt` field, and POST `Location` header

## Note

The GET endpoint uses the server-generated movement ID (`{id}`) rather than `{personId}` as originally described in the issue. The static in-memory storage (`ConcurrentDictionary`) is a placeholder — persistence will be addressed in a later issue.