### PR TITLE
Clean up API feature slice organization across all Features folders

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -10,7 +10,6 @@ An overview of tasks and features to be implemented.
 
 ## Domain
 
-- [ ] Introduce ValueObjects to avoid the Primitive Obsession code smell.
 - [ ] Add validation for domain invariants
 - [ ] Implement domain event versioning for future compatibility
 

--- a/src/Opilo.HazardZoneMonitor.Api/Features/Floors/Configuration/FloorConfiguration.cs
+++ b/src/Opilo.HazardZoneMonitor.Api/Features/Floors/Configuration/FloorConfiguration.cs
@@ -1,8 +1,8 @@
 using Ardalis.GuardClauses;
-using Opilo.HazardZoneMonitor.Api.Features.HazardZones;
+using Opilo.HazardZoneMonitor.Api.Features.HazardZones.Configuration;
 using Opilo.HazardZoneMonitor.Domain.Shared.Primitives;
 
-namespace Opilo.HazardZoneMonitor.Api.Features.Floors;
+namespace Opilo.HazardZoneMonitor.Api.Features.Floors.Configuration;
 
 public sealed record FloorConfiguration
 {

--- a/src/Opilo.HazardZoneMonitor.Api/Features/Floors/Configuration/FloorOptions.cs
+++ b/src/Opilo.HazardZoneMonitor.Api/Features/Floors/Configuration/FloorOptions.cs
@@ -1,4 +1,4 @@
-namespace Opilo.HazardZoneMonitor.Api.Features.Floors;
+namespace Opilo.HazardZoneMonitor.Api.Features.Floors.Configuration;
 
 public sealed record FloorOptions
 {

--- a/src/Opilo.HazardZoneMonitor.Api/Features/Floors/Configuration/FloorOptionsValidator.cs
+++ b/src/Opilo.HazardZoneMonitor.Api/Features/Floors/Configuration/FloorOptionsValidator.cs
@@ -1,9 +1,9 @@
 using System.Collections.ObjectModel;
 using Microsoft.Extensions.Options;
-using Opilo.HazardZoneMonitor.Api.Features.HazardZones;
+using Opilo.HazardZoneMonitor.Api.Features.HazardZones.Configuration;
 using Opilo.HazardZoneMonitor.Domain.Shared.Primitives;
 
-namespace Opilo.HazardZoneMonitor.Api.Features.Floors;
+namespace Opilo.HazardZoneMonitor.Api.Features.Floors.Configuration;
 
 public sealed class FloorOptionsValidator : IValidateOptions<FloorOptions>
 {

--- a/src/Opilo.HazardZoneMonitor.Api/Features/Floors/FloorConfiguration.cs
+++ b/src/Opilo.HazardZoneMonitor.Api/Features/Floors/FloorConfiguration.cs
@@ -18,7 +18,7 @@ public sealed record FloorConfiguration
         init => field = Guard.Against.Null(value);
     } = null!;
 
-    public IReadOnlyList<Coordinate> Outline { get; init; } = [];
+    public IReadOnlyList<Coordinate> Outline { get; } = [];
 
     public IReadOnlyList<HazardZoneConfiguration> HazardZones { get; init; } = [];
 }

--- a/src/Opilo.HazardZoneMonitor.Api/Features/Floors/GetFloors/Feature.cs
+++ b/src/Opilo.HazardZoneMonitor.Api/Features/Floors/GetFloors/Feature.cs
@@ -2,9 +2,11 @@ using System.ComponentModel;
 using Ardalis.Result;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.Extensions.Options;
-using Opilo.HazardZoneMonitor.Domain.Shared.Primitives;
+using Opilo.HazardZoneMonitor.Api.Features.Floors.Configuration;
 using Opilo.HazardZoneMonitor.Api.Shared.Cqrs;
 using Opilo.HazardZoneMonitor.Api.Shared.Features;
+using Opilo.HazardZoneMonitor.Api.Shared.Infrastructure;
+using Opilo.HazardZoneMonitor.Domain.Shared.Primitives;
 
 namespace Opilo.HazardZoneMonitor.Api.Features.Floors.GetFloors;
 

--- a/src/Opilo.HazardZoneMonitor.Api/Features/Floors/GetFloors/GetFloorsResponse.cs
+++ b/src/Opilo.HazardZoneMonitor.Api/Features/Floors/GetFloors/GetFloorsResponse.cs
@@ -1,3 +1,4 @@
+using Opilo.HazardZoneMonitor.Api.Features.Floors.Configuration;
 using Opilo.HazardZoneMonitor.Api.Shared.Cqrs;
 
 namespace Opilo.HazardZoneMonitor.Api.Features.Floors.GetFloors;

--- a/src/Opilo.HazardZoneMonitor.Api/Features/Floors/GetFloors/Handler.cs
+++ b/src/Opilo.HazardZoneMonitor.Api/Features/Floors/GetFloors/Handler.cs
@@ -1,5 +1,6 @@
 using Ardalis.Result;
 using Microsoft.Extensions.Options;
+using Opilo.HazardZoneMonitor.Api.Features.Floors.Configuration;
 using Opilo.HazardZoneMonitor.Api.Shared.Cqrs;
 
 namespace Opilo.HazardZoneMonitor.Api.Features.Floors.GetFloors;

--- a/src/Opilo.HazardZoneMonitor.Api/Features/HazardZones/Configuration/HazardZoneConfiguration.cs
+++ b/src/Opilo.HazardZoneMonitor.Api/Features/HazardZones/Configuration/HazardZoneConfiguration.cs
@@ -1,6 +1,6 @@
 using Opilo.HazardZoneMonitor.Domain.Shared.Primitives;
 
-namespace Opilo.HazardZoneMonitor.Api.Features.HazardZones;
+namespace Opilo.HazardZoneMonitor.Api.Features.HazardZones.Configuration;
 
 public sealed record HazardZoneConfiguration(
     HazardZoneName Name,

--- a/src/Opilo.HazardZoneMonitor.Api/Features/HazardZones/Configuration/HazardZoneOptions.cs
+++ b/src/Opilo.HazardZoneMonitor.Api/Features/HazardZones/Configuration/HazardZoneOptions.cs
@@ -1,4 +1,4 @@
-namespace Opilo.HazardZoneMonitor.Api.Features.HazardZones;
+namespace Opilo.HazardZoneMonitor.Api.Features.HazardZones.Configuration;
 
 public sealed record HazardZoneOptions
 {

--- a/src/Opilo.HazardZoneMonitor.Api/Features/HazardZones/Configuration/HazardZoneOptionsValidator.cs
+++ b/src/Opilo.HazardZoneMonitor.Api/Features/HazardZones/Configuration/HazardZoneOptionsValidator.cs
@@ -1,6 +1,6 @@
 using Microsoft.Extensions.Options;
 
-namespace Opilo.HazardZoneMonitor.Api.Features.HazardZones;
+namespace Opilo.HazardZoneMonitor.Api.Features.HazardZones.Configuration;
 
 public sealed class HazardZoneOptionsValidator : IValidateOptions<HazardZoneOptions>
 {

--- a/src/Opilo.HazardZoneMonitor.Api/Features/HazardZones/GetHazardZones/Feature.cs
+++ b/src/Opilo.HazardZoneMonitor.Api/Features/HazardZones/GetHazardZones/Feature.cs
@@ -2,9 +2,11 @@ using System.ComponentModel;
 using Ardalis.Result;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.Extensions.Options;
-using Opilo.HazardZoneMonitor.Domain.Shared.Primitives;
+using Opilo.HazardZoneMonitor.Api.Features.HazardZones.Configuration;
 using Opilo.HazardZoneMonitor.Api.Shared.Cqrs;
 using Opilo.HazardZoneMonitor.Api.Shared.Features;
+using Opilo.HazardZoneMonitor.Api.Shared.Infrastructure;
+using Opilo.HazardZoneMonitor.Domain.Shared.Primitives;
 
 namespace Opilo.HazardZoneMonitor.Api.Features.HazardZones.GetHazardZones;
 

--- a/src/Opilo.HazardZoneMonitor.Api/Features/HazardZones/GetHazardZones/GetHazardZonesResponse.cs
+++ b/src/Opilo.HazardZoneMonitor.Api/Features/HazardZones/GetHazardZones/GetHazardZonesResponse.cs
@@ -1,3 +1,4 @@
+using Opilo.HazardZoneMonitor.Api.Features.HazardZones.Configuration;
 using Opilo.HazardZoneMonitor.Api.Shared.Cqrs;
 
 namespace Opilo.HazardZoneMonitor.Api.Features.HazardZones.GetHazardZones;

--- a/src/Opilo.HazardZoneMonitor.Api/Features/HazardZones/GetHazardZones/Handler.cs
+++ b/src/Opilo.HazardZoneMonitor.Api/Features/HazardZones/GetHazardZones/Handler.cs
@@ -1,5 +1,6 @@
 using Ardalis.Result;
 using Microsoft.Extensions.Options;
+using Opilo.HazardZoneMonitor.Api.Features.HazardZones.Configuration;
 using Opilo.HazardZoneMonitor.Api.Shared.Cqrs;
 
 namespace Opilo.HazardZoneMonitor.Api.Features.HazardZones.GetHazardZones;

--- a/src/Opilo.HazardZoneMonitor.Api/Features/PersonTracking/Data/IMovementsRepository.cs
+++ b/src/Opilo.HazardZoneMonitor.Api/Features/PersonTracking/Data/IMovementsRepository.cs
@@ -1,7 +1,8 @@
 using Ardalis.Result;
+using Opilo.HazardZoneMonitor.Api.Features.PersonTracking.GetRegisteredPersonMovement;
 using Opilo.HazardZoneMonitor.Domain.Shared.Primitives;
 
-namespace Opilo.HazardZoneMonitor.Api.Features.PersonTracking;
+namespace Opilo.HazardZoneMonitor.Api.Features.PersonTracking.Data;
 
 public interface IMovementsRepository
 {

--- a/src/Opilo.HazardZoneMonitor.Api/Features/PersonTracking/Data/MovementsRepository.cs
+++ b/src/Opilo.HazardZoneMonitor.Api/Features/PersonTracking/Data/MovementsRepository.cs
@@ -2,10 +2,11 @@ using System.Globalization;
 using System.Text.Json;
 using Ardalis.Result;
 using Dapper;
+using Opilo.HazardZoneMonitor.Api.Features.PersonTracking.GetRegisteredPersonMovement;
 using Opilo.HazardZoneMonitor.Api.Shared.Database;
 using Opilo.HazardZoneMonitor.Domain.Shared.Primitives;
 
-namespace Opilo.HazardZoneMonitor.Api.Features.PersonTracking;
+namespace Opilo.HazardZoneMonitor.Api.Features.PersonTracking.Data;
 
 internal sealed class MovementsRepository(IDbConnectionFactory connectionFactory) : IMovementsRepository
 {

--- a/src/Opilo.HazardZoneMonitor.Api/Features/PersonTracking/Data/PersonTrackingSchemaInitializer.cs
+++ b/src/Opilo.HazardZoneMonitor.Api/Features/PersonTracking/Data/PersonTrackingSchemaInitializer.cs
@@ -1,7 +1,7 @@
 using Dapper;
 using Opilo.HazardZoneMonitor.Api.Shared.Database;
 
-namespace Opilo.HazardZoneMonitor.Api.Features.PersonTracking;
+namespace Opilo.HazardZoneMonitor.Api.Features.PersonTracking.Data;
 
 internal sealed class PersonTrackingSchemaInitializer(IDbConnectionFactory connectionFactory) : ISchemaInitializer
 {

--- a/src/Opilo.HazardZoneMonitor.Api/Features/PersonTracking/Feature.cs
+++ b/src/Opilo.HazardZoneMonitor.Api/Features/PersonTracking/Feature.cs
@@ -1,6 +1,8 @@
 using Dapper;
+using Opilo.HazardZoneMonitor.Api.Features.PersonTracking.Data;
 using Opilo.HazardZoneMonitor.Api.Shared.Database;
 using Opilo.HazardZoneMonitor.Api.Shared.Features;
+using Opilo.HazardZoneMonitor.Api.Shared.Infrastructure;
 
 namespace Opilo.HazardZoneMonitor.Api.Features.PersonTracking;
 

--- a/src/Opilo.HazardZoneMonitor.Api/Features/PersonTracking/GetRegisteredPersonMovement/Handler.cs
+++ b/src/Opilo.HazardZoneMonitor.Api/Features/PersonTracking/GetRegisteredPersonMovement/Handler.cs
@@ -1,4 +1,5 @@
 using Ardalis.Result;
+using Opilo.HazardZoneMonitor.Api.Features.PersonTracking.Data;
 using Opilo.HazardZoneMonitor.Api.Shared.Cqrs;
 
 namespace Opilo.HazardZoneMonitor.Api.Features.PersonTracking.GetRegisteredPersonMovement;

--- a/src/Opilo.HazardZoneMonitor.Api/Features/PersonTracking/GetRegisteredPersonMovement/RegisteredPersonMovement.cs
+++ b/src/Opilo.HazardZoneMonitor.Api/Features/PersonTracking/GetRegisteredPersonMovement/RegisteredPersonMovement.cs
@@ -1,7 +1,7 @@
 using Opilo.HazardZoneMonitor.Api.Shared.Cqrs;
 using Opilo.HazardZoneMonitor.Domain.Shared.Primitives;
 
-namespace Opilo.HazardZoneMonitor.Api.Features.PersonTracking;
+namespace Opilo.HazardZoneMonitor.Api.Features.PersonTracking.GetRegisteredPersonMovement;
 
 public sealed class RegisteredPersonMovement : IResponse
 {

--- a/src/Opilo.HazardZoneMonitor.Api/Features/PersonTracking/RegisterPersonMovement/Command.cs
+++ b/src/Opilo.HazardZoneMonitor.Api/Features/PersonTracking/RegisterPersonMovement/Command.cs
@@ -1,3 +1,4 @@
+using Opilo.HazardZoneMonitor.Api.Features.PersonTracking.GetRegisteredPersonMovement;
 using Opilo.HazardZoneMonitor.Api.Shared.Cqrs;
 using Opilo.HazardZoneMonitor.Domain.Shared.Primitives;
 

--- a/src/Opilo.HazardZoneMonitor.Api/Features/PersonTracking/RegisterPersonMovement/Feature.cs
+++ b/src/Opilo.HazardZoneMonitor.Api/Features/PersonTracking/RegisterPersonMovement/Feature.cs
@@ -1,6 +1,7 @@
 using Ardalis.Result;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
+using Opilo.HazardZoneMonitor.Api.Features.PersonTracking.GetRegisteredPersonMovement;
 using Opilo.HazardZoneMonitor.Api.Shared.Cqrs;
 using Opilo.HazardZoneMonitor.Api.Shared.Features;
 

--- a/src/Opilo.HazardZoneMonitor.Api/Features/PersonTracking/RegisterPersonMovement/Handler.cs
+++ b/src/Opilo.HazardZoneMonitor.Api/Features/PersonTracking/RegisterPersonMovement/Handler.cs
@@ -1,4 +1,6 @@
 using Ardalis.Result;
+using Opilo.HazardZoneMonitor.Api.Features.PersonTracking.Data;
+using Opilo.HazardZoneMonitor.Api.Features.PersonTracking.GetRegisteredPersonMovement;
 using Opilo.HazardZoneMonitor.Api.Shared.Cqrs;
 using Opilo.HazardZoneMonitor.Domain.Shared.Abstractions;
 

--- a/src/Opilo.HazardZoneMonitor.Api/Features/Site/Configuration/SiteConfiguration.cs
+++ b/src/Opilo.HazardZoneMonitor.Api/Features/Site/Configuration/SiteConfiguration.cs
@@ -1,0 +1,5 @@
+using Opilo.HazardZoneMonitor.Api.Features.Floors.Configuration;
+
+namespace Opilo.HazardZoneMonitor.Api.Features.Site.Configuration;
+
+public sealed record SiteConfiguration(string Name, IReadOnlyList<FloorConfiguration> Floors);

--- a/src/Opilo.HazardZoneMonitor.Api/Features/Site/Configuration/SiteOptions.cs
+++ b/src/Opilo.HazardZoneMonitor.Api/Features/Site/Configuration/SiteOptions.cs
@@ -1,6 +1,6 @@
 using Opilo.HazardZoneMonitor.Domain.Shared.Primitives;
 
-namespace Opilo.HazardZoneMonitor.Api.Features.Site;
+namespace Opilo.HazardZoneMonitor.Api.Features.Site.Configuration;
 
 public sealed record SiteOptions
 {

--- a/src/Opilo.HazardZoneMonitor.Api/Features/Site/Configuration/SiteOptionsValidator.cs
+++ b/src/Opilo.HazardZoneMonitor.Api/Features/Site/Configuration/SiteOptionsValidator.cs
@@ -1,6 +1,6 @@
 using Microsoft.Extensions.Options;
 
-namespace Opilo.HazardZoneMonitor.Api.Features.Site;
+namespace Opilo.HazardZoneMonitor.Api.Features.Site.Configuration;
 
 public sealed class SiteOptionsValidator : IValidateOptions<SiteOptions>
 {

--- a/src/Opilo.HazardZoneMonitor.Api/Features/Site/GetSite/Feature.cs
+++ b/src/Opilo.HazardZoneMonitor.Api/Features/Site/GetSite/Feature.cs
@@ -1,6 +1,7 @@
 using Ardalis.Result;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.Extensions.Options;
+using Opilo.HazardZoneMonitor.Api.Features.Site.Configuration;
 using Opilo.HazardZoneMonitor.Api.Shared.Cqrs;
 using Opilo.HazardZoneMonitor.Api.Shared.Features;
 

--- a/src/Opilo.HazardZoneMonitor.Api/Features/Site/GetSite/GetSiteResponse.cs
+++ b/src/Opilo.HazardZoneMonitor.Api/Features/Site/GetSite/GetSiteResponse.cs
@@ -1,3 +1,4 @@
+using Opilo.HazardZoneMonitor.Api.Features.Site.Configuration;
 using Opilo.HazardZoneMonitor.Api.Shared.Cqrs;
 
 namespace Opilo.HazardZoneMonitor.Api.Features.Site.GetSite;

--- a/src/Opilo.HazardZoneMonitor.Api/Features/Site/GetSite/Handler.cs
+++ b/src/Opilo.HazardZoneMonitor.Api/Features/Site/GetSite/Handler.cs
@@ -1,6 +1,7 @@
 using Ardalis.Result;
 using Microsoft.Extensions.Options;
-using Opilo.HazardZoneMonitor.Api.Features.Floors;
+using Opilo.HazardZoneMonitor.Api.Features.Floors.Configuration;
+using Opilo.HazardZoneMonitor.Api.Features.Site.Configuration;
 using Opilo.HazardZoneMonitor.Api.Shared.Cqrs;
 
 namespace Opilo.HazardZoneMonitor.Api.Features.Site.GetSite;

--- a/src/Opilo.HazardZoneMonitor.Api/Features/Site/SiteConfiguration.cs
+++ b/src/Opilo.HazardZoneMonitor.Api/Features/Site/SiteConfiguration.cs
@@ -1,5 +1,0 @@
-using Opilo.HazardZoneMonitor.Api.Features.Floors;
-
-namespace Opilo.HazardZoneMonitor.Api.Features.Site;
-
-public sealed record SiteConfiguration(string Name, IReadOnlyList<FloorConfiguration> Floors);

--- a/src/Opilo.HazardZoneMonitor.Api/Shared/Database/CoordinateTypeHandler.cs
+++ b/src/Opilo.HazardZoneMonitor.Api/Shared/Database/CoordinateTypeHandler.cs
@@ -3,7 +3,7 @@ using System.Text.Json;
 using Dapper;
 using Opilo.HazardZoneMonitor.Domain.Shared.Primitives;
 
-namespace Opilo.HazardZoneMonitor.Api.Features.PersonTracking;
+namespace Opilo.HazardZoneMonitor.Api.Shared.Database;
 
 internal sealed class CoordinateTypeHandler : SqlMapper.TypeHandler<Coordinate>
 {

--- a/src/Opilo.HazardZoneMonitor.Api/Shared/Database/GuidTypeHandler.cs
+++ b/src/Opilo.HazardZoneMonitor.Api/Shared/Database/GuidTypeHandler.cs
@@ -1,7 +1,7 @@
 using System.Data;
 using Dapper;
 
-namespace Opilo.HazardZoneMonitor.Api.Features.PersonTracking;
+namespace Opilo.HazardZoneMonitor.Api.Shared.Database;
 
 internal sealed class GuidTypeHandler : SqlMapper.TypeHandler<Guid>
 {

--- a/src/Opilo.HazardZoneMonitor.Api/Shared/Database/PersonIdTypeHandler.cs
+++ b/src/Opilo.HazardZoneMonitor.Api/Shared/Database/PersonIdTypeHandler.cs
@@ -2,7 +2,7 @@ using System.Data;
 using Dapper;
 using Opilo.HazardZoneMonitor.Domain.Shared.Primitives;
 
-namespace Opilo.HazardZoneMonitor.Api.Features.PersonTracking;
+namespace Opilo.HazardZoneMonitor.Api.Shared.Database;
 
 internal sealed class PersonIdTypeHandler : SqlMapper.TypeHandler<PersonId>
 {

--- a/src/Opilo.HazardZoneMonitor.Api/Shared/Infrastructure/FloorNameJsonConverter.cs
+++ b/src/Opilo.HazardZoneMonitor.Api/Shared/Infrastructure/FloorNameJsonConverter.cs
@@ -2,7 +2,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using Opilo.HazardZoneMonitor.Domain.Shared.Primitives;
 
-namespace Opilo.HazardZoneMonitor.Api.Features.Floors;
+namespace Opilo.HazardZoneMonitor.Api.Shared.Infrastructure;
 
 internal sealed class FloorNameJsonConverter : JsonConverter<FloorName>
 {

--- a/src/Opilo.HazardZoneMonitor.Api/Shared/Infrastructure/HazardZoneNameJsonConverter.cs
+++ b/src/Opilo.HazardZoneMonitor.Api/Shared/Infrastructure/HazardZoneNameJsonConverter.cs
@@ -2,7 +2,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using Opilo.HazardZoneMonitor.Domain.Shared.Primitives;
 
-namespace Opilo.HazardZoneMonitor.Api.Features.HazardZones;
+namespace Opilo.HazardZoneMonitor.Api.Shared.Infrastructure;
 
 internal sealed class HazardZoneNameJsonConverter : JsonConverter<HazardZoneName>
 {

--- a/src/Opilo.HazardZoneMonitor.Api/Shared/Infrastructure/PersonIdJsonConverter.cs
+++ b/src/Opilo.HazardZoneMonitor.Api/Shared/Infrastructure/PersonIdJsonConverter.cs
@@ -2,7 +2,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using Opilo.HazardZoneMonitor.Domain.Shared.Primitives;
 
-namespace Opilo.HazardZoneMonitor.Api.Features.PersonTracking;
+namespace Opilo.HazardZoneMonitor.Api.Shared.Infrastructure;
 
 internal sealed class PersonIdJsonConverter : JsonConverter<PersonId>
 {

--- a/tests/Opilo.HazardZoneMonitor.Api.Tests.Unit/Features/Floors/FloorOptionsValidatorTests.cs
+++ b/tests/Opilo.HazardZoneMonitor.Api.Tests.Unit/Features/Floors/FloorOptionsValidatorTests.cs
@@ -1,4 +1,4 @@
-using Opilo.HazardZoneMonitor.Api.Features.Floors;
+using Opilo.HazardZoneMonitor.Api.Features.Floors.Configuration;
 using Opilo.HazardZoneMonitor.Domain.Shared.Primitives;
 using Opilo.HazardZoneMonitor.Tests.Common.TestUtilities.Builders;
 

--- a/tests/Opilo.HazardZoneMonitor.Api.Tests.Unit/Features/Floors/GetFloors/HandlerTests.cs
+++ b/tests/Opilo.HazardZoneMonitor.Api.Tests.Unit/Features/Floors/GetFloors/HandlerTests.cs
@@ -1,6 +1,6 @@
 using Ardalis.Result;
 using Microsoft.Extensions.Options;
-using Opilo.HazardZoneMonitor.Api.Features.Floors;
+using Opilo.HazardZoneMonitor.Api.Features.Floors.Configuration;
 using Opilo.HazardZoneMonitor.Domain.Shared.Primitives;
 using Opilo.HazardZoneMonitor.Api.Features.Floors.GetFloors;
 

--- a/tests/Opilo.HazardZoneMonitor.Api.Tests.Unit/Features/HazardZones/GetHazardZones/HandlerTests.cs
+++ b/tests/Opilo.HazardZoneMonitor.Api.Tests.Unit/Features/HazardZones/GetHazardZones/HandlerTests.cs
@@ -1,6 +1,6 @@
 using Ardalis.Result;
 using Microsoft.Extensions.Options;
-using Opilo.HazardZoneMonitor.Api.Features.HazardZones;
+using Opilo.HazardZoneMonitor.Api.Features.HazardZones.Configuration;
 using Opilo.HazardZoneMonitor.Domain.Shared.Primitives;
 using Opilo.HazardZoneMonitor.Api.Features.HazardZones.GetHazardZones;
 

--- a/tests/Opilo.HazardZoneMonitor.Api.Tests.Unit/Features/HazardZones/HazardZoneOptionsValidatorTests.cs
+++ b/tests/Opilo.HazardZoneMonitor.Api.Tests.Unit/Features/HazardZones/HazardZoneOptionsValidatorTests.cs
@@ -1,4 +1,4 @@
-using Opilo.HazardZoneMonitor.Api.Features.HazardZones;
+using Opilo.HazardZoneMonitor.Api.Features.HazardZones.Configuration;
 using Opilo.HazardZoneMonitor.Domain.Shared.Primitives;
 using Opilo.HazardZoneMonitor.Tests.Common.TestUtilities.Builders;
 

--- a/tests/Opilo.HazardZoneMonitor.Api.Tests.Unit/Features/PersonTracking/GetRegisteredPersonMovement/HandlerTests.cs
+++ b/tests/Opilo.HazardZoneMonitor.Api.Tests.Unit/Features/PersonTracking/GetRegisteredPersonMovement/HandlerTests.cs
@@ -1,6 +1,6 @@
 using Ardalis.Result;
 using NSubstitute;
-using Opilo.HazardZoneMonitor.Api.Features.PersonTracking;
+using Opilo.HazardZoneMonitor.Api.Features.PersonTracking.Data;
 using Opilo.HazardZoneMonitor.Api.Features.PersonTracking.GetRegisteredPersonMovement;
 using Opilo.HazardZoneMonitor.Domain.Shared.Primitives;
 

--- a/tests/Opilo.HazardZoneMonitor.Api.Tests.Unit/Features/PersonTracking/RegisterPersonMovement/HandlerSpecification.cs
+++ b/tests/Opilo.HazardZoneMonitor.Api.Tests.Unit/Features/PersonTracking/RegisterPersonMovement/HandlerSpecification.cs
@@ -1,9 +1,11 @@
 using Ardalis.Result;
 using NSubstitute;
-using Opilo.HazardZoneMonitor.Api.Features.PersonTracking;
+using Opilo.HazardZoneMonitor.Api.Features.PersonTracking.Data;
+using Opilo.HazardZoneMonitor.Api.Features.PersonTracking.GetRegisteredPersonMovement;
 using Opilo.HazardZoneMonitor.Api.Features.PersonTracking.RegisterPersonMovement;
 using Opilo.HazardZoneMonitor.Domain.Shared.Abstractions;
 using Opilo.HazardZoneMonitor.Domain.Shared.Primitives;
+using Handler = Opilo.HazardZoneMonitor.Api.Features.PersonTracking.RegisterPersonMovement.Handler;
 
 namespace Opilo.HazardZoneMonitor.Api.Tests.Unit.Features.PersonTracking.RegisterPersonMovement;
 

--- a/tests/Opilo.HazardZoneMonitor.Api.Tests.Unit/Features/Site/GetSite/HandlerTests.cs
+++ b/tests/Opilo.HazardZoneMonitor.Api.Tests.Unit/Features/Site/GetSite/HandlerTests.cs
@@ -1,7 +1,7 @@
 using Ardalis.Result;
 using Microsoft.Extensions.Options;
-using Opilo.HazardZoneMonitor.Api.Features.Floors;
-using Opilo.HazardZoneMonitor.Api.Features.Site;
+using Opilo.HazardZoneMonitor.Api.Features.Floors.Configuration;
+using Opilo.HazardZoneMonitor.Api.Features.Site.Configuration;
 using Opilo.HazardZoneMonitor.Domain.Shared.Primitives;
 using Opilo.HazardZoneMonitor.Api.Features.Site.GetSite;
 

--- a/tests/Opilo.HazardZoneMonitor.Api.Tests.Unit/Features/Site/SiteOptionsValidatorTests.cs
+++ b/tests/Opilo.HazardZoneMonitor.Api.Tests.Unit/Features/Site/SiteOptionsValidatorTests.cs
@@ -1,4 +1,4 @@
-using Opilo.HazardZoneMonitor.Api.Features.Site;
+using Opilo.HazardZoneMonitor.Api.Features.Site.Configuration;
 using Opilo.HazardZoneMonitor.Domain.Shared.Primitives;
 
 namespace Opilo.HazardZoneMonitor.Api.Tests.Unit.Features.Site;

--- a/tests/Opilo.HazardZoneMonitor.Tests.Common/TestUtilities/Builders/FloorConfigurationBuilder.cs
+++ b/tests/Opilo.HazardZoneMonitor.Tests.Common/TestUtilities/Builders/FloorConfigurationBuilder.cs
@@ -1,5 +1,5 @@
-using Opilo.HazardZoneMonitor.Api.Features.Floors;
-using Opilo.HazardZoneMonitor.Api.Features.HazardZones;
+using Opilo.HazardZoneMonitor.Api.Features.Floors.Configuration;
+using Opilo.HazardZoneMonitor.Api.Features.HazardZones.Configuration;
 using Opilo.HazardZoneMonitor.Domain.Shared.Primitives;
 
 namespace Opilo.HazardZoneMonitor.Tests.Common.TestUtilities.Builders;

--- a/tests/Opilo.HazardZoneMonitor.Tests.Common/TestUtilities/Builders/HazardZoneConfigurationBuilder.cs
+++ b/tests/Opilo.HazardZoneMonitor.Tests.Common/TestUtilities/Builders/HazardZoneConfigurationBuilder.cs
@@ -1,4 +1,4 @@
-using Opilo.HazardZoneMonitor.Api.Features.HazardZones;
+using Opilo.HazardZoneMonitor.Api.Features.HazardZones.Configuration;
 using Opilo.HazardZoneMonitor.Domain.Shared.Primitives;
 
 namespace Opilo.HazardZoneMonitor.Tests.Common.TestUtilities.Builders;

--- a/tests/Opilo.HazardZoneMonitor.Tests.Integration/Features/Floors/FloorConfigurationStartupSpecification.cs
+++ b/tests/Opilo.HazardZoneMonitor.Tests.Integration/Features/Floors/FloorConfigurationStartupSpecification.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
 using Opilo.HazardZoneMonitor.Api;
-using Opilo.HazardZoneMonitor.Api.Features.Floors;
+using Opilo.HazardZoneMonitor.Api.Features.Floors.Configuration;
 using Opilo.HazardZoneMonitor.Domain.Shared.Primitives;
 using Opilo.HazardZoneMonitor.Tests.Common.TestUtilities.Builders;
 using Opilo.HazardZoneMonitor.Tests.Integration.Shared;

--- a/tests/Opilo.HazardZoneMonitor.Tests.Integration/Features/Floors/GetFloorsSpecification.cs
+++ b/tests/Opilo.HazardZoneMonitor.Tests.Integration/Features/Floors/GetFloorsSpecification.cs
@@ -1,10 +1,10 @@
 using System.Net;
 using System.Net.Http.Json;
 using Microsoft.Extensions.Configuration;
-using Opilo.HazardZoneMonitor.Api.Features.Floors;
+using Opilo.HazardZoneMonitor.Api.Features.Floors.Configuration;
 using Opilo.HazardZoneMonitor.Domain.Shared.Primitives;
 using Opilo.HazardZoneMonitor.Api.Features.Floors.GetFloors;
-using Opilo.HazardZoneMonitor.Api.Features.HazardZones;
+using Opilo.HazardZoneMonitor.Api.Features.HazardZones.Configuration;
 using Opilo.HazardZoneMonitor.Tests.Integration.Shared;
 
 namespace Opilo.HazardZoneMonitor.Tests.Integration.Features.Floors;

--- a/tests/Opilo.HazardZoneMonitor.Tests.Integration/Features/HazardZones/GetHazardZonesSpecification.cs
+++ b/tests/Opilo.HazardZoneMonitor.Tests.Integration/Features/HazardZones/GetHazardZonesSpecification.cs
@@ -1,7 +1,7 @@
 using System.Net;
 using System.Net.Http.Json;
 using Microsoft.Extensions.Configuration;
-using Opilo.HazardZoneMonitor.Api.Features.HazardZones;
+using Opilo.HazardZoneMonitor.Api.Features.HazardZones.Configuration;
 using Opilo.HazardZoneMonitor.Api.Features.HazardZones.GetHazardZones;
 using Opilo.HazardZoneMonitor.Domain.Shared.Primitives;
 using Opilo.HazardZoneMonitor.Tests.Integration.Shared;

--- a/tests/Opilo.HazardZoneMonitor.Tests.Integration/Features/HazardZones/HazardZoneConfigurationStartupSpecification.cs
+++ b/tests/Opilo.HazardZoneMonitor.Tests.Integration/Features/HazardZones/HazardZoneConfigurationStartupSpecification.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
 using Opilo.HazardZoneMonitor.Api;
-using Opilo.HazardZoneMonitor.Api.Features.HazardZones;
+using Opilo.HazardZoneMonitor.Api.Features.HazardZones.Configuration;
 using Opilo.HazardZoneMonitor.Domain.Shared.Primitives;
 using Opilo.HazardZoneMonitor.Tests.Common.TestUtilities.Builders;
 using Opilo.HazardZoneMonitor.Tests.Integration.Shared;

--- a/tests/Opilo.HazardZoneMonitor.Tests.Integration/Features/PersonTracking/GetRegisteredPersonMovementSpecification.cs
+++ b/tests/Opilo.HazardZoneMonitor.Tests.Integration/Features/PersonTracking/GetRegisteredPersonMovementSpecification.cs
@@ -1,7 +1,7 @@
 using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
-using Opilo.HazardZoneMonitor.Api.Features.PersonTracking;
+using Opilo.HazardZoneMonitor.Api.Features.PersonTracking.GetRegisteredPersonMovement;
 using Opilo.HazardZoneMonitor.Api.Features.PersonTracking.RegisterPersonMovement;
 using Opilo.HazardZoneMonitor.Domain.Shared.Primitives;
 using Opilo.HazardZoneMonitor.Tests.Integration.Shared;

--- a/tests/Opilo.HazardZoneMonitor.Tests.Integration/Features/PersonTracking/PersonMovementPersistenceSpecification.cs
+++ b/tests/Opilo.HazardZoneMonitor.Tests.Integration/Features/PersonTracking/PersonMovementPersistenceSpecification.cs
@@ -1,6 +1,6 @@
 using System.Net;
 using System.Net.Http.Json;
-using Opilo.HazardZoneMonitor.Api.Features.PersonTracking;
+using Opilo.HazardZoneMonitor.Api.Features.PersonTracking.GetRegisteredPersonMovement;
 using Opilo.HazardZoneMonitor.Tests.Integration.Shared;
 
 namespace Opilo.HazardZoneMonitor.Tests.Integration.Features.PersonTracking;

--- a/tests/Opilo.HazardZoneMonitor.Tests.Integration/Features/PersonTracking/RegisterPersonMovementsSpecification.cs
+++ b/tests/Opilo.HazardZoneMonitor.Tests.Integration/Features/PersonTracking/RegisterPersonMovementsSpecification.cs
@@ -1,6 +1,6 @@
 using System.Net;
 using System.Net.Http.Json;
-using Opilo.HazardZoneMonitor.Api.Features.PersonTracking;
+using Opilo.HazardZoneMonitor.Api.Features.PersonTracking.GetRegisteredPersonMovement;
 using Opilo.HazardZoneMonitor.Api.Features.PersonTracking.RegisterPersonMovement;
 using Opilo.HazardZoneMonitor.Domain.Shared.Primitives;
 using Opilo.HazardZoneMonitor.Tests.Integration.Shared;

--- a/tests/Opilo.HazardZoneMonitor.Tests.Integration/Features/Site/GetSiteConfigurationSpecification.cs
+++ b/tests/Opilo.HazardZoneMonitor.Tests.Integration/Features/Site/GetSiteConfigurationSpecification.cs
@@ -1,8 +1,8 @@
 using System.Net;
 using System.Net.Http.Json;
 using Microsoft.Extensions.Configuration;
-using Opilo.HazardZoneMonitor.Api.Features.Floors;
-using Opilo.HazardZoneMonitor.Api.Features.Site;
+using Opilo.HazardZoneMonitor.Api.Features.Floors.Configuration;
+using Opilo.HazardZoneMonitor.Api.Features.Site.Configuration;
 using Opilo.HazardZoneMonitor.Domain.Shared.Primitives;
 using Opilo.HazardZoneMonitor.Api.Features.Site.GetSite;
 using Opilo.HazardZoneMonitor.Tests.Integration.Shared;

--- a/tests/Opilo.HazardZoneMonitor.Tests.Integration/Shared/ConfigurationExtensions.cs
+++ b/tests/Opilo.HazardZoneMonitor.Tests.Integration/Shared/ConfigurationExtensions.cs
@@ -1,7 +1,7 @@
 using System.Globalization;
-using Opilo.HazardZoneMonitor.Api.Features.Floors;
-using Opilo.HazardZoneMonitor.Api.Features.HazardZones;
-using Opilo.HazardZoneMonitor.Api.Features.Site;
+using Opilo.HazardZoneMonitor.Api.Features.Floors.Configuration;
+using Opilo.HazardZoneMonitor.Api.Features.HazardZones.Configuration;
+using Opilo.HazardZoneMonitor.Api.Features.Site.Configuration;
 using Opilo.HazardZoneMonitor.Domain.Shared.Primitives;
 
 namespace Opilo.HazardZoneMonitor.Tests.Integration.Shared;

--- a/tests/Opilo.HazardZoneMonitor.Tests.Integration/Shared/SerializationOptions.cs
+++ b/tests/Opilo.HazardZoneMonitor.Tests.Integration/Shared/SerializationOptions.cs
@@ -1,8 +1,6 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using Opilo.HazardZoneMonitor.Api.Features.Floors;
-using Opilo.HazardZoneMonitor.Api.Features.HazardZones;
-using Opilo.HazardZoneMonitor.Api.Features.PersonTracking;
+using Opilo.HazardZoneMonitor.Api.Shared.Infrastructure;
 
 namespace Opilo.HazardZoneMonitor.Tests.Integration.Shared;
 


### PR DESCRIPTION
Closes #43

## Summary

This PR reorganizes the API feature slices to improve cohesion and make the vertical slice structure easier to navigate.

## Changes

- **PersonTracking**: Moved cross-cutting infrastructure (Dapper type handlers, JSON converters) to `Shared/Database/` and `Shared/Infrastructure/`. Grouped persistence concerns (`IMovementsRepository`, `MovementsRepository`, `PersonTrackingSchemaInitializer`) into a `Data/` subfolder. Moved `RegisteredPersonMovement` response DTO to `GetRegisteredPersonMovement/`.
- **HazardZones**: Moved `HazardZoneNameJsonConverter` to `Shared/Infrastructure/`.
- **Floors**: Moved `FloorNameJsonConverter` to `Shared/Infrastructure/`.
- **Site**: Added missing `Configuration/` subfolder for `SiteConfiguration` and related options/validator.
- **FloorConfiguration**: Made `Outline` property read-only.

## Verification

- All existing tests pass
- Build succeeds with zero warnings
- No behavioral changes — purely structural reorganization